### PR TITLE
[Feature] Add parsing options for the output string

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,38 @@ Given
 
 To receive `["A", "B"]` as your selection, you can use the following [JSON path expression](https://www.npmjs.com/package/jsonpath) `$[*].value`
 
+## Options for output string parsing
+
+Given the selected options as
+
+```json
+[A, B, C, D]
+```
+
+You can parse the output string to parse the selected options using `parse` option. The default parser is JSON parser.
+The default parser is applied if you do not specifiy any parsing option or `"parse": "json"`. If you want to customize it,
+you can use below options:
+
+```json
+{
+  ...
+  "parse": {
+    "start": "{",  // first string concatenated to output (default: "")
+    "end": "{",  // last string concatenated to output (default: "")
+    "prefix": "'",  // prefix concatenated to each item of output (default: "")
+    "suffix": "'",  // suffix concatenated to each item of output (default: "")
+    "delimiter": ", ",  // delimiter to divide items (default: ",")
+  },
+  ...
+}
+```
+
+The output after the above parser is applied is like:
+
+```
+{'A', 'B', 'C', 'D'}
+```
+
 ## Playground
 
 ```bash

--- a/playground/.vscode/launch.json
+++ b/playground/.vscode/launch.json
@@ -8,7 +8,6 @@
       "skipFiles": ["<node_internals>/**"],
       "args": ["${input:myDynamicParameter}"],
       "program": "${workspaceFolder}/main.js",
-      "preLaunchTask": "myPreBuildTask"
     }
   ],
   "inputs": [
@@ -24,6 +23,13 @@
         "var": "myDynamicParameter-${workspaceId}-${configId}",
         // map options to values
         "unwrap": "$[*].value",
+        "parse": {
+          "start": "{",
+          "end": "}",
+          "prefix": "'",
+          "suffix": "'",
+          "delimiter": "|",
+        },
         "quickPickOptions": {
           "canPickMany": true,
           "ignoreFocusOut": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,15 @@ type WriteOperationOptions = {
   command: string;
   args: string[];
   unwrap?: string;
+  parse?:
+    | {
+        start?: string;
+        end?: string;
+        prefix?: string;
+        suffix?: string;
+        delimiter?: string;
+      }
+    | "json";
   quickPickOptions?: vscode.QuickPickOptions;
 };
 
@@ -131,7 +140,15 @@ async function writeOperation(opts: WriteOperationOptions) {
         } else {
           if (opts.quickPickOptions?.canPickMany) {
             const unwrapped = jp.query(selection, opts.unwrap ?? "*");
-            value = JSON.stringify(unwrapped);
+            if (opts.parse && opts.parse !== "json") {
+              const { start, end, prefix, suffix, delimiter } = opts.parse;
+              value =
+                (start ?? "") +
+                unwrapped.map((op) => (prefix ?? "") + op.toString() + (suffix ?? "")).join(delimiter ?? ",") +
+                (end ?? "");
+            } else {
+              value = JSON.stringify(unwrapped);
+            }
           } else {
             const unwrapped = jp.value(selection, opts.unwrap ?? "$");
             value = JSON.stringify(unwrapped);


### PR DESCRIPTION
I would like to use this extension with more options about the output string, so I add them to this request.

# New options: `parse`

User can simply add `parse` to `launch.json` like other options. I wrote how to use them and the example of them on README.md, so please refer to it.

# Why these options are needed

I was doing Django project, and what I want to do was to write the below command for testing:

```bash
python manage.py test app.tests.unit.test_first_module app.tests.unit.test_second_module app.tests.unit.test_third_module
```

So what I tried is (1) to write a shell script to get all the test files and (2) to create `launch.json` that allows a user to select test modules to run from VSCode prompt. I created `launch.json` that works for (1) and (2). However, since the only format of the output string was JSON, I could not make a string like `test app.tests.unit.test_first_module app.tests.unit.test_second_module app.tests.unit.test_third_module`, whose delimiter is a space character.

With my parser option, I can create any string format I want to.
